### PR TITLE
fix: reset session flag in stop() to allow reinitialization

### DIFF
--- a/src/main/java/com/gtngroup/GTNAPI.java
+++ b/src/main/java/com/gtngroup/GTNAPI.java
@@ -46,7 +46,7 @@ public class GTNAPI {
         if (isInitialised()) {
             throw new RuntimeException("Already initialised. init() can be called only once per session");
         }
-        setInitialised();
+        setInitialised(true);
         return Auth.init();
     }
 
@@ -74,8 +74,8 @@ public class GTNAPI {
     /**
      * internal call to set initialise status
      */
-    private static void setInitialised() {
-        GTNAPI.initialised = true;
+    private static void setInitialised(boolean value) {
+        GTNAPI.initialised = value;
     }
 
 
@@ -86,6 +86,7 @@ public class GTNAPI {
         Auth.logout();
         TradeStreaming.getInstance().disconnect();
         MarketDataStreaming.getInstance().disconnect();
+        setInitialised(false);
     }
 
     /**


### PR DESCRIPTION
Currently, once init() is called, the SDK sets an internal flag marking the session as initialized. However, stop() only logs out and disconnects streams, without resetting this flag. This prevents calling init() again unless the application is restarted.

**Changes**

- Modified setInitialised() to accept a boolean parameter.

- init() now calls setInitialised(true) when initialization succeeds.

- stop() now calls setInitialised(false) to reset the session state.

**Impact**

This change allows SDK users to:

- Safely reinitialize after stopping a session.

- Recover gracefully if initialization fails due to third-party downtime.