### PR TITLE
fix: handle failed token refresh and reauthenticate

### DIFF
--- a/src/main/java/com/gtngroup/Auth.java
+++ b/src/main/java/com/gtngroup/Auth.java
@@ -432,10 +432,18 @@ public class Auth {
                     int http_status = refreshedToken.getInt("http_status");
                     if (http_status == 200) {
                         if (serverToken) {
-                            Shared.getInstance().setServerToken(refreshedToken.getJSONObject("response"));
+                            if (refreshedToken.getJSONObject("response").optString("status").equalsIgnoreCase("FAILED")) {
+                                initInstitution();
+                            } else {
+                                Shared.getInstance().setServerToken(refreshedToken.getJSONObject("response"));
+                            }
                         } else {
-                            // test refreshedToken.getJSONObject("response").put("accessTokenExpiresAt", System.currentTimeMillis() + 30_000L);
-                            Shared.getInstance().setCustomerToken(customerNumber, refreshedToken.getJSONObject("response"));
+                            if (refreshedToken.getJSONObject("response").optString("status").equalsIgnoreCase("FAILED")) {
+                                Shared.getInstance().removeCustomer(customerNumber);
+                                initCustomer(customerNumber);
+                            } else {
+                                Shared.getInstance().setCustomerToken(customerNumber, refreshedToken.getJSONObject("response"));
+                            }
                         }
                         return true;
                     } else {


### PR DESCRIPTION
Currently, the token refresh API may return an HTTP 200 response even
when the refresh operation fails internally (e.g. system errors or
expired refresh tokens). The SDK only checks the top-level HTTP status
and assumes the response contains valid tokens.

As a result, existing tokens may be overwritten with null values,
causing subsequent API calls to fail due to missing access tokens.

Changes

- Added validation of the internal refresh response status before
  updating stored tokens.
- If a server token refresh fails, the SDK now reauthenticates the
  server.
- If a customer token refresh fails, the SDK removes the cached
  customer session and reauthenticates the customer.

Impact

- Prevents token invalidation due to partial refresh failures.
- Allows the SDK to recover automatically from refresh errors without
  requiring application restarts.
