### PR TITLE
Expose customer access token for websocket frontend integration

### DIFF
--- a/src/main/java/com/gtngroup/GTNAPI.java
+++ b/src/main/java/com/gtngroup/GTNAPI.java
@@ -280,5 +280,15 @@ public class GTNAPI {
     public synchronized List<String> getActiveCustomers() {
         return Shared.getInstance().getActiveCustomers();
     }
+
+    /**
+     * Get the current access token for a given customer.
+     *
+     * @param customerNumber the customer identifier
+     * @return the access token for the customer, or null if not available
+     */
+    public String getCustomerAccessToken(String customerNumber) {
+        return Shared.getInstance().getCustomerAccessToken(customerNumber);
+    }
 }
 


### PR DESCRIPTION
Currently, the SDK manages customer authentication and access tokens
internally and does not provide a way to retrieve the access token for a
given customer.

The Market Data WebSocket is intended to be consumed directly by the
frontend client. Since these connections bypass the backend, the
frontend must authenticate directly using the customer access token
managed by the SDK.

Changes

- Added a method to retrieve the current access token for a given
  customer.
- The method is read-only and does not alter authentication or refresh
  behavior.

Impact

This change allows SDK consumers to retrieve the customer access token
from the SDK and return it to the frontend when required.
